### PR TITLE
Added notice that Google no longer supports OAuth1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
-# GTM OAuth: Google Toolbox for Mac - OAuth Controllers #
+> ## :warning: Notice
+> This is a client library for OAuth 1.0. Google
+> [no longer](https://developers.googleblog.com/2015/04/a-final-farewell-to-clientlogin-oauth.html)
+> supports OAuth 1.0. If you're looking for the modern Google OAuth 2.0 library for iOS, macOS, and
+> tvOS, see [GTMAppAuth](https://github.com/google/GTMAppAuth).
+
+# GTM OAuth: Google Toolbox for Mac - OAuth 1.0 Controllers #
 
 **Project site** <https://github.com/google/gtm-oauth><br>
 **Discussion group** <http://groups.google.com/group/gtm-oauth>
 
 The Google Toolbox for Mac OAuth Controllers make it easy for Cocoa
-applications to sign in to services using OAuth for authentication and
+applications to sign in to services using OAuth 1.0 for authentication and
 authorization.
 
 Features include:
 - Complete embedded user interface using WebKit
-- Works with Google APIs and with any standard OAuth provider
+- Works with Google APIs and with any standard OAuth 1.0 provider
 - Handles sign-in, keychain storage of authorization token, and signing of requests
 - Independent of other projects
 
@@ -23,8 +29,8 @@ or submit an [issue](https://github.com/google/gtm-oauth/issues).
 The library incorporates the
 [GTM HTTP Fetcher project](https://github.com/google/gtm-http-fetcher/).
 
-This project is for controllers for services using the OAuth 1 protocol.
-There is a separate project for [OAuth 2 controllers](https://github.com/google/gtm-oauth2).
+This project is for controllers for services using the OAuth 1.0 protocol.
+There is a separate project for [OAuth 2.0 controllers](https://github.com/google/GTMAppAuth).
 
 Other useful classes for OS X and iOS developers are available in the
 [Google Toolbox for Mac](https://github.com/google/google-toolbox-for-mac/).


### PR DESCRIPTION
Made the OAuth version more obvious throughout the Readme.